### PR TITLE
remove deprecated `type: shell` step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,13 +65,14 @@ jobs:
           command: bin/rails db:schema:load --trace
 
       # Run rspec in parallel
-      - type: shell
-        command: |
-          bundle exec rspec --profile 10 \
-                            --format RspecJunitFormatter \
-                            --out test_results/rspec.xml \
-                            --format progress \
-                            $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+      - run:
+          name: Run rspec in parallel
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format RspecJunitFormatter \
+                              --out test_results/rspec.xml \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
 
       # Save test results for timing analysis


### PR DESCRIPTION
Part 2 of [this JIRA issue](https://circleci.atlassian.net/browse/CIRCLE-9133).