### PR TITLE
Pin ruby's version to a particular patch level

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 3
     docker:
-      - image: circleci/ruby:2.4-node
+      - image: circleci/ruby:2.4.2-node
         environment:
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3


### PR DESCRIPTION
Return the build to a working state by pinning the docker image's ruby patch level.

This means that ruby version specified by the Gemfile will match the one being used.

This address issue #5 