### PR TITLE
update to ruby 2.7.2 for ruby-orb test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-ruby '2.7.1'
+ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,7 +260,7 @@ DEPENDENCIES
   web-console (>= 3.7.0)
 
 RUBY VERSION
-   ruby 2.7.1p83
+   ruby 2.7.2p137
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
This ruby orb test clones this project and is failing because its set to 2.7.* the lockfile stops the test by failing fast

https://app.circleci.com/pipelines/github/CircleCI-Public/ruby-orb/315/workflows/201bfa4e-157e-47b0-b40b-9990015fe7f8/jobs/1017

