### PR TITLE
Bump CircleCI/Ruby orb version from 1.1.0 to 1.1.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.1.0
+  ruby: circleci/ruby@1.1.2
   node: circleci/node@2
 
 jobs:


### PR DESCRIPTION
This commit just bumps the patch version up in the example to 1.1.2