### PR TITLE
fixing ruby version error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7-node
+      - image: cimg/ruby:2.7.5-node
     steps:
       - checkout
       - ruby/install-deps
@@ -18,7 +18,7 @@ jobs:
   test:
     parallelism: 3
     docker:
-      - image: cimg/ruby:2.7-node
+      - image: cimg/ruby:2.7.5-node
       - image: circleci/postgres:9.5-alpine
         environment:
           POSTGRES_USER: circleci-demo-ruby


### PR DESCRIPTION
otherwise it was using `2.7.7` ruby, and I was seeing these errors:

```
Your Ruby version is 2.7.7, but your Gemfile specified 2.7.5
```